### PR TITLE
Added a modalias line so the driver is automatically loaded on boot

### DIFF
--- a/apple_bce.c
+++ b/apple_bce.c
@@ -432,5 +432,7 @@ MODULE_LICENSE("GPL");
 MODULE_AUTHOR("MrARM");
 MODULE_DESCRIPTION("Apple BCE Driver");
 MODULE_VERSION("0.01");
+// ROLANDO ZAPPACOSTA: added this for it to get autoloaded when built as a module:
+MODULE_ALIAS("pci:v0000106Bd00001801sv*sd*bc*sc*i*");
 module_init(apple_bce_module_init);
 module_exit(apple_bce_module_exit);


### PR DESCRIPTION
Added a modalias so that the apple-bce driver gets automatically loaded by the Macs having a T2 on boot.
Use case: I boot from an external drive on several different computers, PCs and Macs included