### PR TITLE
apple_bce_probe: fix null pointer dereference in fail: case

### DIFF
--- a/apple_bce.c
+++ b/apple_bce.c
@@ -116,14 +116,16 @@ fail_interrupt:
 fail_interrupt_0:
     pci_free_irq(dev, 0, dev);
 fail:
-    if (bce && bce->dev)
+    if (bce && bce->dev) {
         device_destroy(bce_class, bce->devt);
-    kfree(bce);
 
-    if (!IS_ERR_OR_NULL(bce->reg_mem_mb))
-        pci_iounmap(dev, bce->reg_mem_mb);
-    if (!IS_ERR_OR_NULL(bce->reg_mem_dma))
-        pci_iounmap(dev, bce->reg_mem_dma);
+        if (!IS_ERR_OR_NULL(bce->reg_mem_mb))
+            pci_iounmap(dev, bce->reg_mem_mb);
+        if (!IS_ERR_OR_NULL(bce->reg_mem_dma))
+            pci_iounmap(dev, bce->reg_mem_dma);
+
+        kfree(bce);
+    }
 
     pci_free_irq_vectors(dev);
     pci_release_regions(dev);


### PR DESCRIPTION
The fail case caused following kernel oops:

```
apple-bce: capturing our device
BUG: kernel NULL pointer dereference, address: 0000000000000020
PGD 0 P4D 0
Oops: 0000 [#1] PREEMPT SMP PTI
CPU: 3 PID: 932 Comm: modprobe Tainted: G           O      5.10.12 #4
Hardware name: Apple Inc. MacBookPro15,1/Mac-937A206F2EE63C01, BIOS 1554.60.15.0.0 (iBridge: 18.16.13030.0.0,0) 11/30/2020
RIP: 0010:apple_bce_probe+0x42a/0x4d6 [apple_bce]
Code: ef e8 f2 a2 ce e0 eb 7b 41 bc ed ff ff ff 31 ed eb 10 41 bc ea ff ff ff 31 ed eb 06 41 bc f4 ff ff ff 48 89 ef e8 4e 4e 99 e0 <48> 8b 75 20 48 85 f6 74 11 48 81 fe 00 f0 ff ff 77 08 4c 89 ef e8
RSP: 0018:ffffc9000054fc18 EFLAGS: 00010282
RAX: 0000000000000000 RBX: ffffc9000054fc98 RCX: 0000000000000000
RDX: 0000000000000001 RSI: ffffffffa08f28e2 RDI: 0000000000000000
RBP: 0000000000000000 R08: 0000000000000002 R09: 0000000000000087
R10: ffff8881138c3010 R11: 0000000000000002 R12: 00000000ffffffea
R13: ffff888100fbd800 R14: 0000000000000013 R15: 0000000000000000
FS:  00007f0eb0443b80(0000) GS:ffff88846eac0000(0000) knlGS:0000000000000000
CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
CR2: 0000000000000020 CR3: 000000011411a002 CR4: 00000000003706e0
DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
Call Trace:
 local_pci_probe+0x42/0x80
 ? pci_match_device+0xd7/0x100
 pci_device_probe+0xc7/0x170
 ? sysfs_do_create_link_sd+0x69/0xd0
 really_probe+0xed/0x430
 driver_probe_device+0x4f/0xb0
 device_driver_attach+0xa1/0xb0
 __driver_attach+0x74/0x110
 ? device_driver_attach+0xb0/0xb0
 bus_for_each_dev+0x7a/0xc0
 bus_add_driver+0x10b/0x1c0
 driver_register+0x8b/0xe0
 ? 0xffffffffa0903000
 apple_bce_module_init+0x8c/0xd5 [apple_bce]
 do_one_initcall+0x4d/0x210
 ? kmem_cache_alloc_trace+0x32/0x4e0
 do_init_module+0x5c/0x260
 __do_sys_finit_module+0xa0/0xe0
 do_syscall_64+0x33/0x40
 entry_SYSCALL_64_after_hwframe+0x44/0xa9
RIP: 0033:0x7f0eb0558e39
Code: 00 c3 66 2e 0f 1f 84 00 00 00 00 00 0f 1f 44 00 00 48 89 f8 48 89 f7 48 89 d6 48 89 ca 4d 89 c2 4d 89 c8 4c 8b 4c 24 08 0f 05 <48> 3d 01 f0 ff ff 73 01 c3 48 8b 0d ff 0f 0c 00 f7 d8 64 89 01 48
RSP: 002b:00007fff1aee4bd8 EFLAGS: 00000206 ORIG_RAX: 0000000000000139
RAX: ffffffffffffffda RBX: 00005598989d5b80 RCX: 00007f0eb0558e39
RDX: 0000000000000000 RSI: 00005598981d53a0 RDI: 0000000000000003
RBP: 0000000000040000 R08: 0000000000000000 R09: 00005598989d7260
R10: 0000000000000003 R11: 0000000000000206 R12: 00005598981d53a0
R13: 0000000000000000 R14: 00005598989d5d60 R15: 00005598989d5b80
Modules linked in: apple_bce(O+) des_generic libdes sha1_ssse3 sha1_generic md4 algif_skcipher bnep amdgpu gpu_sched ttm i2c_algo_bit drm_kms_helper brcmfmac hid_lenovo syscopyarea 8250_dw 8250 sysfillrect brcmutil sysimgblt 8250_base usbhid intel_rapl_msr fb_sys_fops serial_mctrl_gpio intel_rapl_common idma64 intel_pch_thermal serial_core virt_dma intel_pmc_core_pltdrv intel_pmc_core hci_uart btbcm btintel apple_gmux apple_bl drm pkcs8_key_parser agpgart efivarfs
CR2: 0000000000000020
---[ end trace 34128af5a2b69617 ]---
RIP: 0010:apple_bce_probe+0x42a/0x4d6 [apple_bce]
Code: ef e8 f2 a2 ce e0 eb 7b 41 bc ed ff ff ff 31 ed eb 10 41 bc ea ff ff ff 31 ed eb 06 41 bc f4 ff ff ff 48 89 ef e8 4e 4e 99 e0 <48> 8b 75 20 48 85 f6 74 11 48 81 fe 00 f0 ff ff 77 08 4c 89 ef e8
RSP: 0018:ffffc9000054fc18 EFLAGS: 00010282
RAX: 0000000000000000 RBX: ffffc9000054fc98 RCX: 0000000000000000
RDX: 0000000000000001 RSI: ffffffffa08f28e2 RDI: 0000000000000000
RBP: 0000000000000000 R08: 0000000000000002 R09: 0000000000000087
R10: ffff8881138c3010 R11: 0000000000000002 R12: 00000000ffffffea
R13: ffff888100fbd800 R14: 0000000000000013 R15: 0000000000000000
FS:  00007f0eb0443b80(0000) GS:ffff88846eac0000(0000) knlGS:0000000000000000
CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
CR2: 0000000000000020 CR3: 000000011411a002 CR4: 00000000003706e0
DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
```

Now it correctly reports failure:

```
apple-bce: capturing our device
apple-bce: probe of 0000:02:00.1 failed with error -22
aaudio: capturing our device
aaudio 0000:02:00.3: enabling device (0000 -> 0002)
aaudio 0000:02:00.3: aaudio: No BCE available
aaudio: probe of 0000:02:00.3 failed with error -22
```

This fix is similar to ones already present in forks:
https://github.com/mikroskeem/mbp2018-bridge-drv/commit/8c4b4006c44d7b11717c96b5918facf73cbc72be
https://github.com/Ecos-hj/mbp2018-bridge-drv/commit/a4196946ec907d8317819262b27a83231a700932