### PR TITLE
vhci: fix page fault after resume

### DIFF
--- a/vhci/vhci.c
+++ b/vhci/vhci.c
@@ -291,7 +291,7 @@ static int bce_vhci_reset_device(struct bce_vhci *vhci, int index, u16 timeout)
             }
         }
         vhci->devices[devid] = NULL;
-        vhci->port_to_device[devid] = 0;
+        vhci->port_to_device[index] = 0;
         bce_vhci_cmd_device_destroy(&vhci->cq, devid);
     }
     status = bce_vhci_cmd_port_reset(&vhci->cq, (u8) index, timeout);


### PR DESCRIPTION
Fixing a typo which causes a page fault during resuming from suspend
```
[  200.701442] bce_vhci_endpoint_reset
[  200.702494] bce_vhci_drop_endpoint 1:12
[  200.703413] bce_vhci_drop_endpoint 1:1
[  200.705476] bce_vhci_drop_endpoint 5:11
[  200.705943] BUG: unable to handle page fault for address: 0000000000001500
[  200.705947] #PF: supervisor write access in kernel mode
[  200.705949] #PF: error_code(0x0002) - not-present page
[  200.705951] PGD 0 P4D 0
[  200.705954] Oops: 0002 [#1] PREEMPT SMP PTI
[  200.705957] CPU: 5 PID: 123 Comm: kworker/5:1 Kdump: loaded Tainted: G         C OE     5.18.5-arch1-1-t2 #1 a4fb705c93d42d9001178203cb5b1deeea0e0c3f
[  200.705961] Hardware name: Apple Inc. MacBookPro16,1/Mac-E1008331FDC96864, BIOS 1731.120.10.0.0 (iBridge: 19.16.15071.0.0,0) 04/24/2022
[  200.705963] Workqueue: usb_hub_wq hub_event
[  200.705968] RIP: 0010:bce_vhci_drop_endpoint+0xda/0xf7 [apple_bce]
```