### PR TITLE
bce: add pci modalias

### DIFF
--- a/apple_bce.c
+++ b/apple_bce.c
@@ -373,6 +373,8 @@ static struct pci_device_id apple_bce_ids[  ] = {
         { 0, },
 };
 
+MODULE_DEVICE_TABLE(pci, apple_bce_ids);
+
 struct dev_pm_ops apple_bce_pci_driver_pm = {
         .suspend = apple_bce_suspend,
         .resume = apple_bce_resume


### PR DESCRIPTION
Note that if the audio part of the module is split out into another module, a similar change will be needed for the separated audio module.

Closes #3, which does the same thing but hard codes the modalias string instead of using MODULE_DEVICE_TABLE.