### PR TITLE
Fix build on kernel versions < 6.8

### DIFF
--- a/vhci/vhci.c
+++ b/vhci/vhci.c
@@ -240,7 +240,11 @@ static int bce_vhci_enable_device(struct usb_hcd *hcd, struct usb_device *udev)
     return 0;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,8,0)
+static int bce_vhci_address_device(struct usb_hcd *hcd, struct usb_device *udev)
+#else
 static int bce_vhci_address_device(struct usb_hcd *hcd, struct usb_device *udev, unsigned int timeout_ms) //TODO: follow timeout
+#endif
 {
     /* This is the same as enable_device, but instead in the old scheme */
     return bce_vhci_enable_device(hcd, udev);


### PR DESCRIPTION
The following error was shown if compiled on kernel versions < 6.8

```
make -C /lib/modules/5.15.0-131-generic/build M=/var/lib/dkms/apple-bce/0.2/build modules
make[1]: Entering directory '/usr/src/linux-headers-5.15.0-131-generic'
  CC [M]  /var/lib/dkms/apple-bce/0.2/build/apple_bce.o
  CC [M]  /var/lib/dkms/apple-bce/0.2/build/mailbox.o
  CC [M]  /var/lib/dkms/apple-bce/0.2/build/queue.o
  CC [M]  /var/lib/dkms/apple-bce/0.2/build/queue_dma.o
  CC [M]  /var/lib/dkms/apple-bce/0.2/build/vhci/vhci.o
  CC [M]  /var/lib/dkms/apple-bce/0.2/build/vhci/queue.o
  CC [M]  /var/lib/dkms/apple-bce/0.2/build/vhci/transfer.o
  CC [M]  /var/lib/dkms/apple-bce/0.2/build/audio/audio.o
  CC [M]  /var/lib/dkms/apple-bce/0.2/build/audio/protocol.o
  CC [M]  /var/lib/dkms/apple-bce/0.2/build/audio/protocol_bce.o
  CC [M]  /var/lib/dkms/apple-bce/0.2/build/audio/pcm.o
/var/lib/dkms/apple-bce/0.2/build/vhci/vhci.c:717:27: error: initialization of ‘int ()(struct usb_hcd, struct usb_device )’ from incompatible pointer type ‘int ()(struct usb_hcd , struct usb_device, unsigned int)’ [-Werror=incompatible-pointer-types]
  717 |         .address_device = bce_vhci_address_device,
      |                           ^~~~~~~
/var/lib/dkms/apple-bce/0.2/build/vhci/vhci.c:717:27: note: (near initialization for ‘bce_vhci_driver.address_device’)
cc1: some warnings being treated as errors
make[2]:  [scripts/Makefile.build:297: /var/lib/dkms/apple-bce/0.2/build/vhci/vhci.o] Error 1
make[2]:  Waiting for unfinished jobs....
make[1]:  [Makefile:1910: /var/lib/dkms/apple-bce/0.2/build] Error 2
make[1]: Leaving directory '/usr/src/linux-headers-5.15.0-131-generic'
make:  [Makefile:22: all] Error 2
```