### PR TITLE
Full S3 support, VHCI cold re-enumeration and aaudio fixes. 

### DIFF
--- a/99-tiny-dfr-restart.rules
+++ b/99-tiny-dfr-restart.rules
@@ -1,0 +1,2 @@
+# Restart tiny-dfr when appletbdrm DRM card appears (e.g. after resume)
+ACTION=="add", SUBSYSTEM=="drm", KERNEL=="card[0-9]*", DRIVERS=="appletbdrm", RUN+="/usr/bin/systemctl restart tiny-dfr"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ The project is divided into 3 main components:
 - VHCI - this is a virtual USB host controller; keyboard, mouse and other system components are provided by this component (other drivers use this host controller to provide more functionality, however USB drivers are not in this project's scope).
 - Audio - a driver for the T2 audio interface, currently only audio output is supported.
 
-Please note that the `master` branch does not currently support system suspend and resume.
+## Suspend/Resume
+
+System suspend and resume (S3) is supported. The driver performs cold re-enumeration of all USB devices on wake, matching the macOS x86 protocol.
+
+### Touch Bar (tiny-dfr) after resume
+
+The Touch Bar display (DFR) is handled by the `appletbdrm` driver and the `tiny-dfr` userspace service. After resume, `tiny-dfr` needs to be restarted because systemd kills it during suspend. To handle this automatically the udev rule can be installed:
+
+```sh
+sudo cp 99-tiny-dfr-restart.rules /etc/udev/rules.d/
+sudo udevadm control --reload-rules
+```
 
 If you want to support me, you can do so by donating to me on PayPal: https://paypal.me/mcmrarm

--- a/audio/audio.h
+++ b/audio/audio.h
@@ -10,9 +10,9 @@
 #define AAUDIO_SIG 0x19870423
 
 #define AAUDIO_DEVICE_MAX_UID_LEN 128
-#define AAUDIO_DEVICE_MAX_INPUT_STREAMS 1
-#define AAUDIO_DEVICE_MAX_OUTPUT_STREAMS 1
-#define AAUDIO_DEVICE_MAX_BUFFER_COUNT 1
+#define AAUDIO_DEIVCE_MAX_INPUT_STREAMS 1
+#define AAUDIO_DEIVCE_MAX_OUTPUT_STREAMS 1
+#define AAUDIO_DEIVCE_MAX_BUFFER_COUNT 1
 
 #define AAUDIO_BUFFER_ID_NONE 0xffu
 
@@ -77,9 +77,9 @@ struct aaudio_subdevice {
     int alsa_id;
     char uid[AAUDIO_DEVICE_MAX_UID_LEN + 1];
     size_t in_stream_cnt;
-    struct aaudio_stream in_streams[AAUDIO_DEVICE_MAX_INPUT_STREAMS];
+    struct aaudio_stream in_streams[AAUDIO_DEIVCE_MAX_INPUT_STREAMS];
     size_t out_stream_cnt;
-    struct aaudio_stream out_streams[AAUDIO_DEVICE_MAX_OUTPUT_STREAMS];
+    struct aaudio_stream out_streams[AAUDIO_DEIVCE_MAX_OUTPUT_STREAMS];
     bool is_pcm;
     struct snd_pcm *pcm;
     struct snd_jack *jack;
@@ -110,6 +110,9 @@ struct aaudio_device {
     int next_alsa_id;
 
     struct completion remote_alive;
+
+    struct work_struct resume_work;
+    bool alive;
 };
 
 void aaudio_handle_notification(struct aaudio_device *a, struct aaudio_msg *msg);

--- a/audio/protocol.c
+++ b/audio/protocol.c
@@ -336,8 +336,20 @@ int aaudio_cmd_get_output_stream_list(struct aaudio_device *a, struct aaudio_msg
 }
 int aaudio_cmd_set_remote_access(struct aaudio_device *a, u64 mode)
 {
-    CMD_DEF_SHARED_AND_SEND(aaudio_msg_write_set_remote_access, mode);
-    CMD_HNDL_REPLY_AND_FREE(aaudio_msg_read_set_remote_access_response);
+    return aaudio_cmd_set_remote_access_timeout(a, mode, 500);
+}
+
+int aaudio_cmd_set_remote_access_timeout(struct aaudio_device *a, u64 mode, unsigned int timeout_ms)
+{
+    int status;
+    struct aaudio_send_ctx sctx;
+    struct aaudio_msg reply = aaudio_reply_alloc();
+
+    status = aaudio_send_cmd_sync(a, &sctx, &reply, timeout_ms, aaudio_msg_write_set_remote_access, mode);
+    if (!status)
+        status = aaudio_msg_read_set_remote_access_response(&reply);
+    aaudio_reply_free(&reply);
+    return status;
 }
 int aaudio_cmd_get_device_list(struct aaudio_device *a, struct aaudio_msg *buf,
         aaudio_device_id_t **dev_l, u64 *dev_cnt)

--- a/audio/protocol.h
+++ b/audio/protocol.h
@@ -139,6 +139,7 @@ int aaudio_cmd_get_input_stream_list(struct aaudio_device *a, struct aaudio_msg 
 int aaudio_cmd_get_output_stream_list(struct aaudio_device *a, struct aaudio_msg *buf, aaudio_device_id_t devid,
         aaudio_object_id_t **str_l, u64 *str_cnt);
 int aaudio_cmd_set_remote_access(struct aaudio_device *a, u64 mode);
+int aaudio_cmd_set_remote_access_timeout(struct aaudio_device *a, u64 mode, unsigned int timeout_ms);
 int aaudio_cmd_get_device_list(struct aaudio_device *a, struct aaudio_msg *buf,
         aaudio_device_id_t **dev_l, u64 *dev_cnt);
 

--- a/audio/protocol_bce.c
+++ b/audio/protocol_bce.c
@@ -129,6 +129,10 @@ static void aaudio_handle_reply(struct aaudio_bce *b, struct aaudio_msg *reply)
         pr_err("aaudio_handle_reply: Tag parse failed: %.4s\n", tag);
         return;
     }
+    if (tagn < 0 || tagn >= AAUDIO_BCE_QUEUE_TAG_COUNT) {
+        pr_err("aaudio_handle_reply: Tag out of range: %.4s (%d)\n", tag, tagn);
+        return;
+    }
 
     spin_lock_irqsave(&b->spinlock, irq_flags);
     entry = b->pending_entries[tagn];

--- a/mailbox.h
+++ b/mailbox.h
@@ -21,7 +21,7 @@ enum bce_message_type {
     BCE_MB_SLEEP_NO_STATE = 0x14,                // to-device
     BCE_MB_RESTORE_NO_STATE = 0x15,              // to-device
     BCE_MB_SAVE_STATE_AND_SLEEP = 0x17,          // to-device
-    BCE_MB_RESTORE_STATE_AND_WAKE = 0x18,        // to-device
+    BCE_MB_RESTORE_STATE_AND_WAKE = 0x1B,        // to-device (was 0x18, fixed to match macOS)
     BCE_MB_SAVE_STATE_AND_SLEEP_FAILURE = 0x19,  // from-device
     BCE_MB_SAVE_RESTORE_STATE_COMPLETE = 0x1A,   // from-device
 };

--- a/queue_dma.c
+++ b/queue_dma.c
@@ -153,6 +153,7 @@ static struct bce_segment_list_element_hostinfo *bce_map_segment_list(
         el->addr = sg->dma_address;
         el->length = sg->length;
         header->data_size += el->length;
+        ++el;
     }
 
     /* DMA map */

--- a/vhci/command.h
+++ b/vhci/command.h
@@ -52,7 +52,7 @@ enum bce_vhci_endpoint_state {
 static inline int bce_vhci_cmd_controller_enable(struct bce_vhci_command_queue *q, u8 busNum, u16 *portMask)
 {
     int status;
-    struct bce_vhci_message cmd, res;
+    struct bce_vhci_message cmd = {0}, res = {0};
     cmd.cmd = BCE_VHCI_CMD_CONTROLLER_ENABLE;
     cmd.param1 = 0x7100u | busNum;
     status = bce_vhci_command_queue_execute(q, &cmd, &res, BCE_VHCI_CMD_TIMEOUT_LONG);
@@ -62,54 +62,63 @@ static inline int bce_vhci_cmd_controller_enable(struct bce_vhci_command_queue *
 }
 static inline int bce_vhci_cmd_controller_disable(struct bce_vhci_command_queue *q)
 {
-    struct bce_vhci_message cmd, res;
+    struct bce_vhci_message cmd = {0}, res = {0};
     cmd.cmd = BCE_VHCI_CMD_CONTROLLER_DISABLE;
     return bce_vhci_command_queue_execute(q, &cmd, &res, BCE_VHCI_CMD_TIMEOUT_LONG);
 }
 static inline int bce_vhci_cmd_controller_start(struct bce_vhci_command_queue *q)
 {
-    struct bce_vhci_message cmd, res;
+    struct bce_vhci_message cmd = {0}, res = {0};
     cmd.cmd = BCE_VHCI_CMD_CONTROLLER_START;
     return bce_vhci_command_queue_execute(q, &cmd, &res, BCE_VHCI_CMD_TIMEOUT_LONG);
 }
 static inline int bce_vhci_cmd_controller_pause(struct bce_vhci_command_queue *q)
 {
-    struct bce_vhci_message cmd, res;
+    struct bce_vhci_message cmd = {0}, res = {0};
     cmd.cmd = BCE_VHCI_CMD_CONTROLLER_PAUSE;
     return bce_vhci_command_queue_execute(q, &cmd, &res, BCE_VHCI_CMD_TIMEOUT_LONG);
 }
 
 static inline int bce_vhci_cmd_port_power_on(struct bce_vhci_command_queue *q, bce_vhci_port_t port)
 {
-    struct bce_vhci_message cmd, res;
+    struct bce_vhci_message cmd = {0}, res = {0};
     cmd.cmd = BCE_VHCI_CMD_PORT_POWER_ON;
     cmd.param1 = port;
     return bce_vhci_command_queue_execute(q, &cmd, &res, BCE_VHCI_CMD_TIMEOUT_SHORT);
 }
 static inline int bce_vhci_cmd_port_power_off(struct bce_vhci_command_queue *q, bce_vhci_port_t port)
 {
-    struct bce_vhci_message cmd, res;
+    struct bce_vhci_message cmd = {0}, res = {0};
     cmd.cmd = BCE_VHCI_CMD_PORT_POWER_OFF;
     cmd.param1 = port;
     return bce_vhci_command_queue_execute(q, &cmd, &res, BCE_VHCI_CMD_TIMEOUT_SHORT);
 }
-static inline int bce_vhci_cmd_port_resume(struct bce_vhci_command_queue *q, bce_vhci_port_t port)
+static inline int bce_vhci_cmd_port_resume_ex(struct bce_vhci_command_queue *q, bce_vhci_port_t port,
+        struct bce_vhci_message *reply)
 {
-    struct bce_vhci_message cmd, res;
+    int status;
+    struct bce_vhci_message cmd = {0}, res = {0};
     cmd.cmd = BCE_VHCI_CMD_PORT_RESUME;
     cmd.param1 = port;
-    return bce_vhci_command_queue_execute(q, &cmd, &res, BCE_VHCI_CMD_TIMEOUT_LONG);
+    status = bce_vhci_command_queue_execute(q, &cmd, &res, BCE_VHCI_CMD_TIMEOUT_LONG);
+    if (reply)
+        *reply = res;
+    return status;
+}
+static inline int bce_vhci_cmd_port_resume(struct bce_vhci_command_queue *q, bce_vhci_port_t port)
+{
+    return bce_vhci_cmd_port_resume_ex(q, port, NULL);
 }
 static inline int bce_vhci_cmd_port_suspend(struct bce_vhci_command_queue *q, bce_vhci_port_t port)
 {
-    struct bce_vhci_message cmd, res;
+    struct bce_vhci_message cmd = {0}, res = {0};
     cmd.cmd = BCE_VHCI_CMD_PORT_SUSPEND;
     cmd.param1 = port;
     return bce_vhci_command_queue_execute(q, &cmd, &res, BCE_VHCI_CMD_TIMEOUT_LONG);
 }
 static inline int bce_vhci_cmd_port_reset(struct bce_vhci_command_queue *q, bce_vhci_port_t port, u32 timeout)
 {
-    struct bce_vhci_message cmd, res;
+    struct bce_vhci_message cmd = {0}, res = {0};
     cmd.cmd = BCE_VHCI_CMD_PORT_RESET;
     cmd.param1 = port;
     cmd.param2 = timeout;
@@ -117,7 +126,7 @@ static inline int bce_vhci_cmd_port_reset(struct bce_vhci_command_queue *q, bce_
 }
 static inline int bce_vhci_cmd_port_disable(struct bce_vhci_command_queue *q, bce_vhci_port_t port)
 {
-    struct bce_vhci_message cmd, res;
+    struct bce_vhci_message cmd = {0}, res = {0};
     cmd.cmd = BCE_VHCI_CMD_PORT_DISABLE;
     cmd.param1 = port;
     return bce_vhci_command_queue_execute(q, &cmd, &res, BCE_VHCI_CMD_TIMEOUT_SHORT);
@@ -126,7 +135,7 @@ static inline int bce_vhci_cmd_port_status(struct bce_vhci_command_queue *q, bce
         u32 clearFlags, u32 *resStatus)
 {
     int status;
-    struct bce_vhci_message cmd, res;
+    struct bce_vhci_message cmd = {0}, res = {0};
     cmd.cmd = BCE_VHCI_CMD_PORT_STATUS;
     cmd.param1 = port;
     cmd.param2 = clearFlags & 0x560000;
@@ -140,7 +149,7 @@ static inline int bce_vhci_cmd_device_create(struct bce_vhci_command_queue *q, b
         bce_vhci_device_t *dev)
 {
     int status;
-    struct bce_vhci_message cmd, res;
+    struct bce_vhci_message cmd = {0}, res = {0};
     cmd.cmd = BCE_VHCI_CMD_DEVICE_CREATE;
     cmd.param1 = port;
     status = bce_vhci_command_queue_execute(q, &cmd, &res, BCE_VHCI_CMD_TIMEOUT_SHORT);
@@ -150,7 +159,7 @@ static inline int bce_vhci_cmd_device_create(struct bce_vhci_command_queue *q, b
 }
 static inline int bce_vhci_cmd_device_destroy(struct bce_vhci_command_queue *q, bce_vhci_device_t dev)
 {
-    struct bce_vhci_message cmd, res;
+    struct bce_vhci_message cmd = {0}, res = {0};
     cmd.cmd = BCE_VHCI_CMD_DEVICE_DESTROY;
     cmd.param1 = dev;
     return bce_vhci_command_queue_execute(q, &cmd, &res, BCE_VHCI_CMD_TIMEOUT_LONG);
@@ -159,7 +168,7 @@ static inline int bce_vhci_cmd_device_destroy(struct bce_vhci_command_queue *q, 
 static inline int bce_vhci_cmd_endpoint_create(struct bce_vhci_command_queue *q, bce_vhci_device_t dev,
         struct usb_endpoint_descriptor *desc)
 {
-    struct bce_vhci_message cmd, res;
+    struct bce_vhci_message cmd = {0}, res = {0};
     int endpoint_type = usb_endpoint_type(desc);
     int maxp = usb_endpoint_maxp(desc);
     int maxp_burst = usb_endpoint_maxp_mult(desc) * maxp;
@@ -175,7 +184,7 @@ static inline int bce_vhci_cmd_endpoint_create(struct bce_vhci_command_queue *q,
 }
 static inline int bce_vhci_cmd_endpoint_destroy(struct bce_vhci_command_queue *q, bce_vhci_device_t dev, u8 endpoint)
 {
-    struct bce_vhci_message cmd, res;
+    struct bce_vhci_message cmd = {0}, res = {0};
     cmd.cmd = BCE_VHCI_CMD_ENDPOINT_DESTROY;
     cmd.param1 = dev | (endpoint << 8);
     return bce_vhci_command_queue_execute(q, &cmd, &res, BCE_VHCI_CMD_TIMEOUT_SHORT);
@@ -184,7 +193,7 @@ static inline int bce_vhci_cmd_endpoint_set_state(struct bce_vhci_command_queue 
         enum bce_vhci_endpoint_state newState, enum bce_vhci_endpoint_state *retState)
 {
     int status;
-    struct bce_vhci_message cmd, res;
+    struct bce_vhci_message cmd = {0}, res = {0};
     cmd.cmd = BCE_VHCI_CMD_ENDPOINT_SET_STATE;
     cmd.param1 = dev | (endpoint << 8);
     cmd.param2 = (u64) newState;
@@ -195,7 +204,7 @@ static inline int bce_vhci_cmd_endpoint_set_state(struct bce_vhci_command_queue 
 }
 static inline int bce_vhci_cmd_endpoint_reset(struct bce_vhci_command_queue *q, bce_vhci_device_t dev, u8 endpoint)
 {
-    struct bce_vhci_message cmd, res;
+    struct bce_vhci_message cmd = {0}, res = {0};
     cmd.cmd = BCE_VHCI_CMD_ENDPOINT_RESET;
     cmd.param1 = dev | (endpoint << 8);
     return bce_vhci_command_queue_execute(q, &cmd, &res, BCE_VHCI_CMD_TIMEOUT_SHORT);

--- a/vhci/queue.h
+++ b/vhci/queue.h
@@ -6,6 +6,7 @@
 
 #define VHCI_EVENT_QUEUE_EL_COUNT 256
 #define VHCI_EVENT_PENDING_COUNT 32
+#define VHCI_CMD_PENDING_COUNT 64
 
 struct bce_vhci;
 struct bce_vhci_event_queue;
@@ -46,6 +47,12 @@ struct bce_vhci_event_queue {
 struct bce_vhci_command_queue_completion {
     struct bce_vhci_message *result;
     struct completion completion;
+    u16 expected_cmd;
+    u32 expected_param1;
+    bool waiting;
+    struct bce_vhci_message pending[VHCI_CMD_PENDING_COUNT];
+    u16 pending_head;
+    u16 pending_count;
 };
 struct bce_vhci_command_queue {
     struct bce_vhci_message_queue *mq;
@@ -72,5 +79,6 @@ void bce_vhci_command_queue_destroy(struct bce_vhci_command_queue *cq);
 int bce_vhci_command_queue_execute(struct bce_vhci_command_queue *cq, struct bce_vhci_message *req,
         struct bce_vhci_message *res, unsigned long timeout);
 void bce_vhci_command_queue_deliver_completion(struct bce_vhci_command_queue *cq, struct bce_vhci_message *msg);
+void bce_vhci_command_queue_clear_pending(struct bce_vhci_command_queue *cq, const char *reason);
 
 #endif //BCE_VHCI_QUEUE_H

--- a/vhci/transfer.h
+++ b/vhci/transfer.h
@@ -2,6 +2,7 @@
 #define BCEDRIVER_TRANSFER_H
 
 #include <linux/usb.h>
+#include <linux/wait.h>
 #include "queue.h"
 #include "command.h"
 #include "../queue.h"
@@ -32,6 +33,9 @@ struct bce_vhci_transfer_queue {
     struct spinlock urb_lock;
     struct mutex pause_lock;
     struct list_head giveback_urb_list;
+    wait_queue_head_t drain_waitq;
+    wait_queue_head_t sq_out_wait_queue;
+    atomic_t sq_out_pending;
 
     struct work_struct w_reset;
 };
@@ -64,6 +68,7 @@ int bce_vhci_transfer_queue_do_pause(struct bce_vhci_transfer_queue *q);
 int bce_vhci_transfer_queue_do_resume(struct bce_vhci_transfer_queue *q);
 int bce_vhci_transfer_queue_pause(struct bce_vhci_transfer_queue *q, enum bce_vhci_pause_source src);
 int bce_vhci_transfer_queue_resume(struct bce_vhci_transfer_queue *q, enum bce_vhci_pause_source src);
+void bce_vhci_transfer_queue_quiesce(struct bce_vhci_transfer_queue *q);
 void bce_vhci_transfer_queue_request_reset(struct bce_vhci_transfer_queue *q);
 
 int bce_vhci_urb_create(struct bce_vhci_transfer_queue *q, struct urb *urb);

--- a/vhci/vhci.h
+++ b/vhci/vhci.h
@@ -11,6 +11,8 @@ struct bce_vhci_device {
     struct bce_vhci_transfer_queue tq[32];
     u32 tq_mask;
 };
+#define BCE_VHCI_SYS_EVENT_LOG_SIZE 32
+
 struct bce_vhci {
     struct apple_bce_device *dev;
     dev_t vdevt;
@@ -37,7 +39,15 @@ struct bce_vhci {
     struct bce_vhci_device *devices[16];
     struct workqueue_struct *tq_state_wq;
     struct work_struct w_fw_events;
+    struct work_struct w_port_change;
+    struct delayed_work w_dfr_reset;
+    struct usb_device *dfr_reset_udev;
+    bool dfr_needs_boot_reset;
     unsigned long port_change_pending;
+    spinlock_t sys_event_log_lock;
+    struct bce_vhci_message sys_event_log[BCE_VHCI_SYS_EVENT_LOG_SIZE];
+    u32 sys_event_log_head;
+    u32 sys_event_log_count;
 };
 
 int __init bce_vhci_module_init(void);
@@ -49,5 +59,6 @@ int bce_vhci_start(struct usb_hcd *hcd);
 void bce_vhci_stop(struct usb_hcd *hcd);
 
 struct bce_vhci *bce_vhci_from_hcd(struct usb_hcd *hcd);
+void bce_vhci_dump_recent_system_events(struct bce_vhci *vhci, const struct bce_vhci_message *req);
 
 #endif //BCE_VHCI_H


### PR DESCRIPTION
Tested on a MacBookPro 16,1 running 6.18.5-arch1-Watanare-T2-1-t2

Working S3 suspend/resume for T2 MacBooks, using info from macOS x86 kext disassembly (BridgeAudioController, AppleUSBVHCIBCE).

BCE:
  - change BCE_MB_RESTORE_STATE_AND_WAKE opcode from 0x18 -> 0x1B
  - correct wake ordering, PUP 0x1B mailbox -> doorbell -> timestamp
  - forbid runtime PM and D3cold for T2 PCI device (see impl notes) 
 VHCI:
  - cold re-enumeration on resume (ControllerEnable + ControllerStart + PortPowerOn + usb_root_hub_lost_power) , suprisingly exactly what macOS does
  - transfer queue quiesce and DMA drain on suspend
  - cmd queue now has cancellation protocol, pending completion queue
  - touchbar deferred reset on cold boot only (see impl notes)
audio:
  - non-blocking suspend/resume with deferred T2 re-handshake work queue
  - GPR validation, alive handshake, remote access, stream re-registration

added 99-tiny-dfr-restart.rules udev rule, see README