### PR TITLE
Audio fix

### DIFF
--- a/audio/audio.c
+++ b/audio/audio.c
@@ -2,6 +2,7 @@
 #include <linux/spinlock.h>
 #include <linux/module.h>
 #include <linux/random.h>
+#include <linux/workqueue.h>
 #include <sound/core.h>
 #include <sound/initval.h>
 #include <sound/pcm.h>
@@ -20,6 +21,17 @@ static int aaudio_init_cmd(struct aaudio_device *a);
 static int aaudio_init_bs(struct aaudio_device *a);
 static void aaudio_init_dev(struct aaudio_device *a, aaudio_device_id_t dev_id);
 static void aaudio_free_dev(struct aaudio_subdevice *sdev);
+static void aaudio_handle_timestamp_work(struct work_struct *ws);
+static void aaudio_queue_timestamp_work(struct aaudio_device *a, aaudio_device_id_t devid,
+                                        ktime_t os_timestamp, u64 dev_timestamp);
+
+struct aaudio_timestamp_work_struct {
+    struct work_struct ws;
+    struct aaudio_device *a;
+    aaudio_device_id_t devid;
+    ktime_t os_timestamp;
+    u64 dev_timestamp;
+};
 
 static int aaudio_probe(struct pci_dev *dev, const struct pci_device_id *id)
 {
@@ -63,6 +75,11 @@ static int aaudio_probe(struct pci_dev *dev, const struct pci_device_id *id)
     device_link_add(aaudio->dev, aaudio->bce->dev, DL_FLAG_PM_RUNTIME | DL_FLAG_AUTOREMOVE_CONSUMER);
 
     init_completion(&aaudio->remote_alive);
+    aaudio->timestamp_wq = alloc_ordered_workqueue("aaudio_timestamp", WQ_MEM_RECLAIM);
+    if (!aaudio->timestamp_wq) {
+        status = -ENOMEM;
+        goto fail;
+    }
     INIT_LIST_HEAD(&aaudio->subdevice_list);
 
     /* Init: set an unknown flag in the bitset */
@@ -134,6 +151,8 @@ static int aaudio_probe(struct pci_dev *dev, const struct pci_device_id *id)
 fail_snd:
     snd_card_free(aaudio->card);
 fail:
+    if (aaudio && aaudio->timestamp_wq)
+        destroy_workqueue(aaudio->timestamp_wq);
     if (aaudio && aaudio->dev)
         device_destroy(aaudio_class, aaudio->devt);
     kfree(aaudio);
@@ -158,6 +177,8 @@ static void aaudio_remove(struct pci_dev *dev)
     struct aaudio_subdevice *sdev;
     struct aaudio_device *aaudio = pci_get_drvdata(dev);
 
+    if (aaudio->timestamp_wq)
+        destroy_workqueue(aaudio->timestamp_wq);
     snd_card_free(aaudio->card);
     while (!list_empty(&aaudio->subdevice_list)) {
         sdev = list_first_entry(&aaudio->subdevice_list, struct aaudio_subdevice, list);
@@ -177,6 +198,8 @@ static int aaudio_suspend(struct device *dev)
 {
     struct aaudio_device *aaudio = pci_get_drvdata(to_pci_dev(dev));
 
+    if (aaudio->timestamp_wq)
+        flush_workqueue(aaudio->timestamp_wq);
     if (aaudio_cmd_set_remote_access(aaudio, AAUDIO_REMOTE_ACCESS_OFF))
         dev_warn(aaudio->dev, "Failed to reset remote access\n");
 
@@ -611,16 +634,54 @@ void aaudio_handle_cmd_timestamp(struct aaudio_device *a, struct aaudio_msg *msg
 {
     ktime_t time_os = ktime_get_boottime();
     struct aaudio_send_ctx sctx;
-    struct aaudio_subdevice *sdev;
     u64 devid, timestamp, update_seed;
     aaudio_msg_read_update_timestamp(msg, &devid, &timestamp, &update_seed);
     dev_dbg(a->dev, "Received timestamp update for dev=%llx ts=%llx seed=%llx\n", devid, timestamp, update_seed);
 
-    sdev = aaudio_find_dev_by_dev_id(a, devid);
-    aaudio_handle_timestamp(sdev, time_os, timestamp);
-
     aaudio_send_cmd_response(a, &sctx, msg,
             aaudio_msg_write_update_timestamp_response);
+    aaudio_queue_timestamp_work(a, devid, time_os, timestamp);
+}
+
+static void aaudio_handle_timestamp_work(struct work_struct *ws)
+{
+    struct aaudio_timestamp_work_struct *work =
+        container_of(ws, struct aaudio_timestamp_work_struct, ws);
+    struct aaudio_subdevice *sdev;
+
+    sdev = aaudio_find_dev_by_dev_id(work->a, work->devid);
+    if (!sdev) {
+        dev_dbg(work->a->dev, "Timestamp update for unknown device id=%llx\n", work->devid);
+        goto out;
+    }
+    aaudio_handle_timestamp(sdev, work->os_timestamp, work->dev_timestamp);
+
+out:
+    kfree(work);
+}
+
+static void aaudio_queue_timestamp_work(struct aaudio_device *a, aaudio_device_id_t devid,
+                                        ktime_t os_timestamp, u64 dev_timestamp)
+{
+    struct aaudio_timestamp_work_struct *work;
+
+    if (!a->timestamp_wq)
+        return;
+
+    work = kmalloc(sizeof(*work), GFP_ATOMIC);
+    if (!work) {
+        dev_warn_ratelimited(a->dev, "Dropping timestamp update due to OOM\n");
+        return;
+    }
+
+    INIT_WORK(&work->ws, aaudio_handle_timestamp_work);
+    work->a = a;
+    work->devid = devid;
+    work->os_timestamp = os_timestamp;
+    work->dev_timestamp = dev_timestamp;
+
+    if (!queue_work(a->timestamp_wq, &work->ws))
+        kfree(work);
 }
 
 void aaudio_handle_command(struct aaudio_device *a, struct aaudio_msg *msg)

--- a/audio/audio.h
+++ b/audio/audio.h
@@ -110,6 +110,7 @@ struct aaudio_device {
     int next_alsa_id;
 
     struct completion remote_alive;
+    struct workqueue_struct *timestamp_wq;
 };
 
 void aaudio_handle_notification(struct aaudio_device *a, struct aaudio_msg *msg);

--- a/audio/pcm.c
+++ b/audio/pcm.c
@@ -210,7 +210,6 @@ static snd_pcm_uframes_t aaudio_pcm_pointer(struct snd_pcm_substream *substream)
     snd_pcm_sframes_t buffer_time_length;
 
     if (!stream->started || stream->waiting_for_first_ts) {
-        pr_warn("aaudio_pcm_pointer while not started\n");
         return 0;
     }
 
@@ -285,6 +284,10 @@ static void aaudio_handle_stream_timestamp(struct snd_pcm_substream *substream, 
 
     stream = aaudio_pcm_stream(substream);
     snd_pcm_stream_lock_irqsave(substream, flags);
+    if (!stream->started) {
+        snd_pcm_stream_unlock_irqrestore(substream, flags);
+        return;
+    }
     stream->remote_timestamp = timestamp;
     if (stream->waiting_for_first_ts) {
         stream->waiting_for_first_ts = false;

--- a/audio/pcm.c
+++ b/audio/pcm.c
@@ -304,7 +304,7 @@ void aaudio_handle_timestamp(struct aaudio_subdevice *sdev, ktime_t os_timestamp
 
     substream = sdev->pcm->streams[SNDRV_PCM_STREAM_PLAYBACK].substream;
     if (substream)
-        aaudio_handle_stream_timestamp(substream, dev_timestamp);
+        aaudio_handle_stream_timestamp(substream, os_timestamp);
     substream = sdev->pcm->streams[SNDRV_PCM_STREAM_CAPTURE].substream;
     if (substream)
         aaudio_handle_stream_timestamp(substream, os_timestamp);

--- a/audio/protocol_bce.c
+++ b/audio/protocol_bce.c
@@ -95,6 +95,7 @@ int __aaudio_send_cmd_sync(struct aaudio_bce *b, struct aaudio_send_ctx *ctx, st
     DECLARE_COMPLETION_ONSTACK(cmpl);
     ent.msg = reply;
     ent.cmpl = &cmpl;
+    clear_bit(ctx->tag_n, b->timed_out_tags);
     b->pending_entries[ctx->tag_n] = &ent;
     __aaudio_send(b, ctx); /* unlocks the spinlock */
     ctx->timeout = wait_for_completion_timeout(&cmpl, ctx->timeout);
@@ -102,9 +103,12 @@ int __aaudio_send_cmd_sync(struct aaudio_bce *b, struct aaudio_send_ctx *ctx, st
         /* Remove the pending queue entry; this will be normally handled by the completion route but
          * during a timeout it won't */
         spin_lock_irqsave(&b->spinlock, ctx->irq_flags);
-        if (b->pending_entries[ctx->tag_n] == &ent)
+        if (b->pending_entries[ctx->tag_n] == &ent) {
             b->pending_entries[ctx->tag_n] = NULL;
+            set_bit(ctx->tag_n, b->timed_out_tags);
+        }
         spin_unlock_irqrestore(&b->spinlock, ctx->irq_flags);
+        pr_warn_ratelimited("aaudio_send_cmd_sync: timeout waiting for tag S%03d\n", ctx->tag_n);
         return -ETIMEDOUT;
     }
     return 0;
@@ -133,12 +137,15 @@ static void aaudio_handle_reply(struct aaudio_bce *b, struct aaudio_msg *reply)
     spin_lock_irqsave(&b->spinlock, irq_flags);
     entry = b->pending_entries[tagn];
     if (entry) {
+        clear_bit(tagn, b->timed_out_tags);
         if (reply->size < entry->msg->size)
             entry->msg->size = reply->size;
         memcpy(entry->msg->data, reply->data, entry->msg->size);
         complete(entry->cmpl);
 
         b->pending_entries[tagn] = NULL;
+    } else if (test_and_clear_bit(tagn, b->timed_out_tags)) {
+        pr_debug("aaudio_handle_reply: Late reply for timed-out tag: %.4s\n", tag);
     } else {
         pr_err("aaudio_handle_reply: No queued item found for tag: %.4s\n", tag);
     }

--- a/audio/protocol_bce.h
+++ b/audio/protocol_bce.h
@@ -3,6 +3,7 @@
 
 #include "protocol.h"
 #include "../queue.h"
+#include <linux/bitmap.h>
 
 #define AAUDIO_BCE_QUEUE_ELEMENT_SIZE 0x1000
 #define AAUDIO_BCE_QUEUE_ELEMENT_COUNT 20
@@ -29,6 +30,7 @@ struct aaudio_bce {
     struct aaudio_bce_queue qout;
     int tag_num;
     struct aaudio_bce_queue_entry *pending_entries[AAUDIO_BCE_QUEUE_TAG_COUNT];
+    unsigned long timed_out_tags[BITS_TO_LONGS(AAUDIO_BCE_QUEUE_TAG_COUNT)];
     struct spinlock spinlock;
 };
 


### PR DESCRIPTION
Issues adressed in this PR:

- aaudio_handle_reply: No queued item found for tag: Sxxx
- aaudio_pcm_pointer while not started
- repeated timeout path around __aaudio_send_cmd_sync / aaudio_cmd_stop_io / aaudio_handle_timestamp
- aaudio aaudio: invalid position: ..., pos = ..., buffer size = 16640, period size = 1

Issues were causing choppy playback, spamming logs and causing instability in pm sequence.
There seems to be an audio routing issue in Gnome not caused by the patch. I'm not sure if this needs to be adressed in the driver because it works in KDE without issues. The issue is only of minor nature. Audio output has to be changed manually in settings.

The patch was carefully tested with internal speakers, headphones,bluetooth, Massive Attack, Tool, Moderat and Lulu Rouge.