### PR TITLE
audio/pcm: use host os_timestamp for PLAYBACK to fix reload crash

### DIFF
--- a/audio/pcm.c
+++ b/audio/pcm.c
@@ -301,7 +301,7 @@ void aaudio_handle_timestamp(struct aaudio_subdevice *sdev, ktime_t os_timestamp
 
     substream = sdev->pcm->streams[SNDRV_PCM_STREAM_PLAYBACK].substream;
     if (substream)
-        aaudio_handle_stream_timestamp(substream, dev_timestamp);
+        aaudio_handle_stream_timestamp(substream, os_timestamp);
     substream = sdev->pcm->streams[SNDRV_PCM_STREAM_CAPTURE].substream;
     if (substream)
         aaudio_handle_stream_timestamp(substream, os_timestamp);


### PR DESCRIPTION
PLAYBACK used dev_timestamp from the T2 coprocessor clock domain,
which drifts from the host's ktime_get_boottime() after module reload.
This produced wild position values in aaudio_pcm_pointer, triggering
XRUN and a scheduling-while-atomic panic when snd_pcm_do_stop ran
from DMA IRQ context.

Switch PLAYBACK to os_timestamp (host boottime at message receipt),
matching what CAPTURE already does. The mailbox transit delay (~100
microseconds at most) is negligible in a 347 ms ALSA buffer and
eliminates the crash entirely.
