### PR TITLE
audio/pcm: skip period_elapsed for streams that are not started

### DIFF
--- a/audio/audio.h
+++ b/audio/audio.h
@@ -83,6 +83,7 @@ struct aaudio_subdevice {
     bool is_pcm;
     struct snd_pcm *pcm;
     struct snd_jack *jack;
+    struct work_struct stop_work;
 };
 struct aaudio_alsa_pcm_id_mapping {
     const char *name;

--- a/audio/pcm.c
+++ b/audio/pcm.c
@@ -285,6 +285,10 @@ static void aaudio_handle_stream_timestamp(struct snd_pcm_substream *substream, 
 
     stream = aaudio_pcm_stream(substream);
     snd_pcm_stream_lock_irqsave(substream, flags);
+    if (!stream->started) {
+        snd_pcm_stream_unlock_irqrestore(substream, flags);
+        return;
+    }
     stream->remote_timestamp = timestamp;
     if (stream->waiting_for_first_ts) {
         stream->waiting_for_first_ts = false;

--- a/audio/pcm.c
+++ b/audio/pcm.c
@@ -1,5 +1,6 @@
 #include "pcm.h"
 #include "audio.h"
+#include <linux/workqueue.h>
 
 static u64 aaudio_get_alsa_fmtbit(struct aaudio_apple_description *desc)
 {
@@ -178,23 +179,29 @@ static void aaudio_pcm_start(struct snd_pcm_substream *substream)
     pr_debug("aaudio: Started the audio device in %lluns\n", ktime_to_ns(time_end - time_start));
 }
 
+static void aaudio_pcm_stop_work(struct work_struct *work)
+{
+    struct aaudio_subdevice *sdev = container_of(work, struct aaudio_subdevice, stop_work);
+    aaudio_cmd_stop_io(sdev->a, sdev->dev_id);
+}
+
 static int aaudio_pcm_trigger(struct snd_pcm_substream *substream, int cmd)
 {
     struct aaudio_subdevice *sdev = snd_pcm_substream_chip(substream);
     struct aaudio_stream *stream = aaudio_pcm_stream(substream);
     pr_debug("aaudio_pcm_trigger %x\n", cmd);
 
-    /* We only supports triggers on the #0 buffer */
     if (substream->number != 0)
         return 0;
     switch (cmd) {
         case SNDRV_PCM_TRIGGER_START:
+            cancel_work_sync(&sdev->stop_work);
             aaudio_pcm_start(substream);
             stream->started = 1;
             break;
         case SNDRV_PCM_TRIGGER_STOP:
-            aaudio_cmd_stop_io(sdev->a, sdev->dev_id);
             stream->started = 0;
+            schedule_work(&sdev->stop_work);
             break;
         default:
             return -EINVAL;
@@ -265,6 +272,7 @@ int aaudio_create_pcm(struct aaudio_subdevice *sdev)
     }
     if (!id_mapping->name)
         sdev->alsa_id = sdev->a->next_alsa_id++;
+    INIT_WORK(&sdev->stop_work, aaudio_pcm_stop_work);
     err = snd_pcm_new(sdev->a->card, sdev->uid, sdev->alsa_id,
             (int) sdev->out_stream_cnt, (int) sdev->in_stream_cnt, &pcm);
     if (err < 0)


### PR DESCRIPTION
## Problem

On PREEMPT(full) kernels, connecting speakers or headphones to the 3.5mm jack causes a kernel crash:

```
BUG: scheduling while atomic: irq/80-bce_dma/758/0x00000002
```

The T2 chip sends continuous timestamp events for all registered audio devices, even when no ALSA stream is open. When a jack is connected, ALSA calls \`snd_pcm_period_elapsed\`, which can trigger \`snd_pcm_do_stop\` → \`aaudio_pcm_trigger(STOP)\` → \`aaudio_cmd_stop_io\` → \`wait_for_completion_timeout\` inside the BCE DMA BH handler (atomic context). This also causes a deadlock when called from PipeWire's main thread: the RT data thread holds a lock the main thread needs, while the main thread blocks waiting for T2 to respond.

## Fix

Three commits:

1. **Skip `period_elapsed` for stopped streams** — guard `aaudio_handle_stream_timestamp` with `!stream->started` to avoid calling `snd_pcm_period_elapsed` on streams that are not running.

2. **Use `os_timestamp` for playback** — fixes a reload crash when the timestamp function receives an incompatible device timestamp for playback streams.

3. **Defer `stop_io` to a workqueue** — `aaudio_cmd_stop_io` blocks waiting for a T2 reply, which is unsafe in both atomic context and from PipeWire's main thread. Always defer it via `schedule_work`. In `TRIGGER_START`, use `cancel_work_sync` to cancel any pending (not yet running) stop before starting, avoiding a start/stop race without blocking callers unnecessarily.

## Testing

Tested on MacBook Pro 16,1 (T2) running Arch Linux with kernel 7.0.12 (PREEMPT full). Previously crashed immediately on speaker/headphone connection. Now:
- Speaker and headphone connection no longer crashes
- Audio continues working correctly during Discord calls with XRUNs
- Volume control works without PipeWire deadlock